### PR TITLE
소켓설정변경

### DIFF
--- a/src/modules/socket/index.js
+++ b/src/modules/socket/index.js
@@ -1,5 +1,6 @@
 import socketIOClient from "socket.io-client";
+import host from "config";
 
-let Socket = socketIOClient(process.env.REACT_APP_API_URL);
+let Socket = socketIOClient(host);
 
 export default Socket;


### PR DESCRIPTION
기존에는 소켓의 주소가 aws로 고정되어 있었음.
지금은 host로 바꿈. 

* host는 config.js에서 앱을 실행할 때 설정하는 환경변수에 의해 정해짐.