### PR TITLE
getTopGrouplistrequest function & display it group page

### DIFF
--- a/src/actions/Commons/TopList.js
+++ b/src/actions/Commons/TopList.js
@@ -88,7 +88,7 @@ export function GetTopDesignerListFailure() {
 
 export function GetTopGroupListRequest(page) {
   return (dispatch) => {
-    return fetch(`${host}/group/TopList`, {
+    return fetch(`${host}/group/topGroupList/1/like`, {
       headers: { "Content-Type": "application/json" },
       method: "get"
     }).then((response) => {

--- a/src/components/Groups/GroupList/GroupList.js
+++ b/src/components/Groups/GroupList/GroupList.js
@@ -5,6 +5,7 @@ import { Grid } from "semantic-ui-react";
 import Sorting from "components/Commons/Sorting";
 import Button from "components/Commons/Button";
 import ScrollGroupListContainer from "containers/Groups/ScrollGroupListContainer";
+import ScrollTopGroupListContainer from "containers/Groups/ScrollTopGroupListContainer";
 import ContentBox from "components/Commons/ContentBox";
 import group_bg from "source/group_bg.jpg";
 import StyleGuide from "StyleGuide";
@@ -155,6 +156,7 @@ class GroupList extends Component {
         </Content>
         <Content>
           <Wrapper className="listWrap">
+            <ScrollTopGroupListContainer/> 
             {this.state.rendering && <ScrollGroupListContainer sort={sort} history={this.props.history}/>}
           </Wrapper>
         </Content>

--- a/src/containers/Groups/ScrollTopGroupListContainer/ScrollTopGroupListContainer.js
+++ b/src/containers/Groups/ScrollTopGroupListContainer/ScrollTopGroupListContainer.js
@@ -1,0 +1,45 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { GetTopGroupListRequest } from "actions/Commons/TopList";
+import ScrollList from "components/Commons/ScrollList";
+import Group from "components/Groups/Group";
+
+class ScrollTopGroupListContainer extends Component {
+  componentWillMount(){
+    this.props.GetTopGroupListRequest(0, this.props.sort, this.props.keyword);
+    // props가 바뀌면 제일 첫번째 페이지 리스트부터 새로 불러옴
+  }
+  getList = (page) => {
+    return this.props.GetTopGroupListRequest(page, this.props.sort, this.props.keyword);
+    // ScrollList에서는 그 다음 페이지부터 불러옴
+  }
+
+  render() {
+    return(
+      <div>
+        <ScrollList getListRequest={this.getList}
+                    ListComponent={Group}
+                    type="Group"
+                    dataList={this.props.dataList} dataListAdded={this.props.dataListAdded}
+                    mobile={16} tablet={5} computer={4} largeScreen={2} widescreen={2} customClass="largeCustom"/>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    dataList: state.GroupList.status.GroupList,
+    dataListAdded: state.GroupList.status.GroupListAdded
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+      GetTopGroupListRequest: (page, sort, keyword) => {
+        return dispatch(GetTopGroupListRequest(page, sort, keyword))
+      }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ScrollTopGroupListContainer);

--- a/src/containers/Groups/ScrollTopGroupListContainer/ScrollTopGroupListContainer.js
+++ b/src/containers/Groups/ScrollTopGroupListContainer/ScrollTopGroupListContainer.js
@@ -10,7 +10,7 @@ class ScrollTopGroupListContainer extends Component {
     // props가 바뀌면 제일 첫번째 페이지 리스트부터 새로 불러옴
   }
   getList = (page) => {
-    return this.props.GetTopGroupListRequest(page, this.props.sort, this.props.keyword);
+    return this.props.GetTopGroupListRequest(page);
     // ScrollList에서는 그 다음 페이지부터 불러옴
   }
 

--- a/src/containers/Groups/ScrollTopGroupListContainer/index.js
+++ b/src/containers/Groups/ScrollTopGroupListContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ScrollTopGroupListContainer";


### PR DESCRIPTION
GetTopGroupListRequest 함수를 만들고, 그룹 페이지에서 이를 띄울 수 있게 ScrollTopGroupListRequest 파일을 만들었습니다. 현재 TopList에서 인기그룹으로 지정된 것이 없어 그룹 데이터들을 두 번 부르는 형식으로 나타나고 있습니다.

백엔드 쪽에서 이에 해당하는 데이터들을 지정해주면 정상적으로 디스플레이되지 않을까 생각됩니다.